### PR TITLE
Fix blob content type upload

### DIFF
--- a/backend/commands/storage.py
+++ b/backend/commands/storage.py
@@ -1,7 +1,17 @@
 from utils.helpers import StateHelper
+from azure.storage.blob import ContentSettings
+import mimetypes
 
 async def write_buffer_to_blob(buffer, state: StateHelper, filename: str):
   safe_filename = filename.replace(" ", "_")
   buffer.seek(0)
   client = state.storage
-  await client.upload_blob(data=buffer, name=safe_filename, overwrite=True)
+  content_type, _ = mimetypes.guess_type(safe_filename)
+  if content_type is None:
+    content_type = "application/octet-stream"
+  await client.upload_blob(
+    data=buffer,
+    name=safe_filename,
+    overwrite=True,
+    content_settings=ContentSettings(content_type=content_type)
+  )


### PR DESCRIPTION
## Summary
- ensure uploaded buffers to Azure storage use the correct MIME type

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: f-string unmatched '[' in postgres.py)*

------
https://chatgpt.com/codex/tasks/task_e_6870878a805883259adb09c806f7c81f